### PR TITLE
ISSUE 310 FIX

### DIFF
--- a/src/main/java/com/github/fppt/jedismock/operations/hashes/HSet.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/hashes/HSet.java
@@ -34,11 +34,11 @@ class HSet extends AbstractRedisOperation {
         for(int i = 1; i < params().size(); i = i + 2){
             Slice field = params().get(i);
             Slice value = params().get(i+1);
+            Slice oldValue = hsetValue(hash, field, value);
             if (value.length() > 1000) {
                 RMHash cls = base().getHash(hash);
                 cls.upgradeEncoding();
             }
-            Slice oldValue = hsetValue(hash, field, value);
 
             if(oldValue == null) {
                 count++;

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/hashes/HashOperationsTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/hashes/HashOperationsTest.java
@@ -299,4 +299,13 @@ public class HashOperationsTest {
         assertEquals("", jedis.hget("foo", "bar"));
     }
 
+    @TestTemplate
+    public void testHsetDoesntFailOnLongPayload(Jedis jedis) {
+        // 1001 symbol string
+        String key = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        jedis.hset("foo", "bar", key);
+        assertEquals(key, jedis.hget("foo", "bar"));
+    }
+
+
 }

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/hashes/HashOperationsTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/hashes/HashOperationsTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.exceptions.JedisDataException;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -302,9 +303,11 @@ public class HashOperationsTest {
     @TestTemplate
     public void testHsetDoesntFailOnLongPayload(Jedis jedis) {
         // 1001 symbol string
-        String key = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-        jedis.hset("foo", "bar", key);
-        assertEquals(key, jedis.hget("foo", "bar"));
+        char[] buf = new char[1001];
+        Arrays.fill(buf, 'a');
+        String value = new String(buf);
+        jedis.hset("foo", "bar", value);
+        assertEquals(value, jedis.hget("foo", "bar"));
     }
 
 


### PR DESCRIPTION
решение [бага 310 из основного репозитория](https://github.com/fppt/jedis-mock/issues/310)

fix fppt/jedis-mock#310

проблема была в неправильном заполнении метаинформации об объекте - вызывалась функция для изменения кодировки до того, как объект был создан, и падала с NullPointerException